### PR TITLE
Use OTTOMAN_CONNECTION_STRING as connection string

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+const process = require('process');
 const express = require('express');
 const swaggerUi = require('swagger-ui-express');
 const YAML = require('yamljs');
@@ -23,12 +24,7 @@ app.use((err, req, res, next) => {
 
 const main = async () => {
   try {
-    await ottoman.connect({
-      bucketName: 'travel-sample',
-      connectionString: 'couchbase://localhost:8091',
-      username: 'Administrator',
-      password: 'password',
-    });
+    await ottoman.connect(process.env.OTTOMAN_CONNECTION_STRING);
     await ottoman.start();
     const port = 4500;
     app.listen(port, () => {


### PR DESCRIPTION
The README talks about using an .env file, but the code example used
hardcoded credentials. This commit replaces those with the value of the
OTTOMAN_CONNECTION_STRING environment variable.